### PR TITLE
Register webhook methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@actito/data-model-sdk",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -82,7 +82,7 @@ describe("profile", () => {
     expect(profileId.toString()).toBe("7");
   });
 
-  it("register profile webhook", async () => {
+  it("registers webhook", async () => {
     mocked.mockImplementationOnce(() => ({ ok: true, json: () => ({ id: 123 }) }));
     const { id } = await registerWebhook(PROFILE_TABLE, WebhookType.CREATE, "https://www.example.com", true);
     expectFetch({

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -1,6 +1,6 @@
 import { init } from "../init";
-import { createProfile, deleteProfile, getProfile, getProfiles, updateProfile } from "../profiles";
-import { IAPIProfileBody, IProfileRecord } from "../types";
+import { createProfile, deleteProfile, getProfile, getProfiles, updateProfile, registerWebhook } from "../profiles";
+import { IAPIProfileBody, IProfileRecord, WebhookType } from "../types";
 import { checkLastCall, credentials } from "./helpers";
 
 const PROFILE_TABLE = "Clients";
@@ -80,6 +80,19 @@ describe("profile", () => {
       }
     });
     expect(profileId.toString()).toBe("7");
+  });
+
+  it("register profile webhook", async () => {
+    mocked.mockImplementationOnce(() => ({ ok: true, json: () => ({ id: 123 }) }));
+    const { id } = await registerWebhook(PROFILE_TABLE, WebhookType.CREATE, "https://www.example.com", true);
+    expectFetch({
+      url: "https://test.actito.be/ActitoWebServices/ws/v4/entity/product/table/Clients/webhookSubscription",
+      options: {
+        method: "POST",
+        body: '{"eventType":"CREATE","isActive":true,"targetUrl":"https://www.example.com"}'
+      }
+    });
+    expect(id.toString()).toBe("123");
   });
 
   it("deletes profile", async () => {

--- a/src/__tests__/tables.test.ts
+++ b/src/__tests__/tables.test.ts
@@ -96,7 +96,7 @@ describe("tables", () => {
     });
   });
 
-  it("register profile webhook", async () => {
+  it("registers webhook", async () => {
     mocked.mockImplementationOnce(() => ({ ok: true, json: () => ({ id: 123 }) }));
     const { id } = await registerWebhook(CUSTOM_TABLE, WebhookType.CREATE, "https://www.example.com", true);
     expectFetch({

--- a/src/__tests__/tables.test.ts
+++ b/src/__tests__/tables.test.ts
@@ -1,6 +1,7 @@
 import { init } from "../init";
-import { addRecord, deleteRecord, getRecord, getRecords, increment, updateRecord } from "../tables";
+import { addRecord, deleteRecord, getRecord, getRecords, increment, updateRecord, registerWebhook } from "../tables";
 import { checkLastCall, credentials } from "./helpers";
+import { WebhookType } from "../types";
 
 const CUSTOM_TABLE = "OfferAssignments";
 const RECORD_ID = "20";
@@ -93,6 +94,19 @@ describe("tables", () => {
       url: `https://test.actito.be/ActitoWebServices/ws/v4/entity/product/customTable/${CUSTOM_TABLE}/record/${RECORD_ID}`,
       options: { method: "DELETE" }
     });
+  });
+
+  it("register profile webhook", async () => {
+    mocked.mockImplementationOnce(() => ({ ok: true, json: () => ({ id: 123 }) }));
+    const { id } = await registerWebhook(CUSTOM_TABLE, WebhookType.CREATE, "https://www.example.com", true);
+    expectFetch({
+      url: `https://test.actito.be/ActitoWebServices/ws/v4/entity/product/customTable/${CUSTOM_TABLE}/webhookSubscription`,
+      options: {
+        method: "POST",
+        body: '{"eventType":"CREATE","isActive":true,"targetUrl":"https://www.example.com"}'
+      }
+    });
+    expect(id.toString()).toBe("123");
   });
 
   it("increments record", async () => {

--- a/src/helpers/builders.ts
+++ b/src/helpers/builders.ts
@@ -1,0 +1,11 @@
+import { IAPIWebhookBody, WebhookType } from "../types";
+
+export function webhookBody(targetUrl: string, type: WebhookType, isActive: boolean, onFields?: string[], headers?: { [key: string]: string }): IAPIWebhookBody {
+    return {
+        eventType: type,
+        headers: headers,
+        isActive: isActive,
+        onFields: onFields,
+        targetUrl: targetUrl
+    };
+}

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -1,6 +1,7 @@
 import { actitoDelete, actitoGet, actitoPost, actitoPut } from "./helpers/http";
 import { apiProfileToProfile, profileToAPIProfile } from "./helpers/translators";
-import { IProfileRecord } from "./types";
+import { webhookBody } from "./helpers/builders";
+import { IProfileRecord, WebhookType } from "./types";
 
 export async function createProfile(table: string, profileSpec: IProfileRecord): Promise<{ profileId: string }> {
   return await actitoPost(`table/${table}/profile`, profileToAPIProfile(profileSpec));
@@ -35,4 +36,8 @@ export async function updateProfile(
 
 export async function deleteProfile(table: string, profileId: string) {
   await actitoDelete(`table/${table}/profile/${profileId}`);
+}
+
+export async function registerWebhook(table: string, type: WebhookType, targetUrl: string, isActive: boolean, onFields?: string[], headers?: { [key: string]: string }) {
+  return await actitoPost(`table/${table}/webhookSubscription`, webhookBody(targetUrl, type, isActive, onFields, headers));
 }

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -1,6 +1,7 @@
 import { actitoDelete, actitoGet, actitoPost, actitoPut } from "./helpers/http";
 import { objectToProperties, propertiesToObject } from "./helpers/translators";
-import { IAPIProperty, IAPISearch, IAPISort } from "./types";
+import { webhookBody } from "./helpers/builders";
+import { IAPIProperty, IAPISearch, IAPISort, WebhookType } from "./types";
 
 export async function addRecord(tableId: string, record: object) {
   return actitoPost(`customTable/${tableId}/record`, { properties: objectToProperties(record) });
@@ -36,4 +37,8 @@ export async function increment(tableId: string, recordId: string, field: string
 
 export async function deleteRecord(tableId: string, recordId: string) {
   return await actitoDelete(`customTable/${tableId}/record/${recordId}`);
+}
+
+export async function registerWebhook(table: string, type: WebhookType, targetUrl: string, isActive: boolean, onFields?: string[], headers?: { [key: string]: string }) {
+  return await actitoPost(`customTable/${table}/webhookSubscription`, webhookBody(targetUrl, type, isActive, onFields, headers));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,3 +63,19 @@ export interface IProfileRecord {
     way: string;
   };
 }
+
+export enum WebhookType {
+  CREATE = "CREATE",
+  UPDATE = "UPDATE",
+  DELETE = "DELETE",
+  UPDATED_SUBSCRIPTION = "UPDATED_SUBSCRIPTION",
+  UPDATED_SEGMENT = "UPDATED_SEGMENT"
+}
+
+export interface IAPIWebhookBody {
+  eventType: WebhookType,
+  headers?: { [key: string]: string },
+  isActive: boolean,
+  onFields?: string[],
+  targetUrl: string
+}


### PR DESCRIPTION
New pull request for #8 .

Modifications :
* Added a new builders.ts module, with one method : webhookBody
  * created the body of the call to the API to create a webhook (the body as the same structure for custom tables and profile tables)
* Added new types for webhooks
  * an enum for the supported types of webhooks
  * an interface for the body for the API call
* Added methods to register webhooks in profiles.ts and tables.ts
* Added tests

I already tested with a live script in my test licence